### PR TITLE
Fix handling of URI query params. Bump telesign sdk version to 2.2.3.

### DIFF
--- a/lib/telesign/rest.rb
+++ b/lib/telesign/rest.rb
@@ -7,7 +7,7 @@ require 'securerandom'
 require 'net/http/persistent'
 
 module Telesign
-  SDK_VERSION = '2.2.2'
+  SDK_VERSION = '2.2.3'
 
   # The TeleSign RestClient is a generic HTTP REST client that can be extended to make requests against any of
   # TeleSign's REST API endpoints.
@@ -192,10 +192,9 @@ module Telesign
 
       resource_uri = URI.parse("#{@rest_endpoint}#{resource}")
 
-      request = method_function.new(resource_uri.request_uri)
-
       encoded_fields = ''
       if %w[POST PUT].include? method_name
+        request = method_function.new(resource_uri.request_uri)
         if content_type == "application/x-www-form-urlencoded"
           unless params.empty?
             encoded_fields = URI.encode_www_form(params, Encoding::UTF_8)
@@ -208,6 +207,7 @@ module Telesign
         end
       else
         resource_uri.query = URI.encode_www_form(params, Encoding::UTF_8)
+        request = method_function.new(resource_uri.request_uri)
       end
 
       headers = RestClient.generate_telesign_headers(@customer_id,

--- a/telesign.gemspec
+++ b/telesign.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name                    = 'telesign'
-  s.version                 = '2.2.2'
+  s.version                 = '2.2.3'
   s.licenses                = ['MIT']
   s.date                    = '2017-05-25'
   s.summary                 = 'TeleSign Ruby SDK'

--- a/test/test_rest.rb
+++ b/test/test_rest.rb
@@ -140,7 +140,7 @@ class TestRest < Test::Unit::TestCase
     test_resource = '/test/resource'
     test_params = {:'test' => "123_\u03ff_test"}
 
-    stub_request(:get, 'localhost/test/resource').to_return(body: '{}')
+    stub_request(:get, 'localhost/test/resource?test=123_%CF%BF_test').to_return(body: '{}')
 
     client = Telesign::RestClient.new(@customer_id,
                                       @api_key,
@@ -148,15 +148,12 @@ class TestRest < Test::Unit::TestCase
 
     client.get(test_resource, **test_params)
 
-
-    assert_requested :get, 'http://localhost/test/resource'
-    # webmock doesn't seem to track query params...?
-    # assert_requested :get, 'http://localhost/test/resource', query: {'test' => '123_%CF%BF_test'}
-    assert_requested :get, 'http://localhost/test/resource', body: ''
-    assert_not_requested :get, 'http://localhost/test/resource', headers: {'Content-Type' => /.*\S.*/}
-    assert_requested :get, 'http://localhost/test/resource', headers: {'x-ts-auth-method' => 'HMAC-SHA256'}
-    assert_requested :get, 'http://localhost/test/resource', headers: {'x-ts-nonce' => /.*\S.*/}
-    assert_requested :get, 'http://localhost/test/resource', headers: {'Date' => /.*\S.*/}
+    assert_requested :get, 'http://localhost/test/resource?test=123_%CF%BF_test'
+    assert_requested :get, 'http://localhost/test/resource?test=123_%CF%BF_test', body: ''
+    assert_not_requested :get, 'http://localhost/test/resource?test=123_%CF%BF_test', headers: {'Content-Type' => /.*\S.*/}
+    assert_requested :get, 'http://localhost/test/resource?test=123_%CF%BF_test', headers: {'x-ts-auth-method' => 'HMAC-SHA256'}
+    assert_requested :get, 'http://localhost/test/resource?test=123_%CF%BF_test', headers: {'x-ts-nonce' => /.*\S.*/}
+    assert_requested :get, 'http://localhost/test/resource?test=123_%CF%BF_test', headers: {'Date' => /.*\S.*/}
   end
 
   def test_rest_client_put
@@ -185,7 +182,7 @@ class TestRest < Test::Unit::TestCase
     test_resource = '/test/resource'
     test_params = {:'test' => "123_\u03ff_test"}
 
-    stub_request(:delete, 'localhost/test/resource').to_return(body: '{}')
+    stub_request(:delete, 'localhost/test/resource?test=123_%CF%BF_test').to_return(body: '{}')
 
     client = Telesign::RestClient.new(@customer_id,
                                       @api_key,
@@ -193,14 +190,12 @@ class TestRest < Test::Unit::TestCase
 
     client.delete(test_resource, **test_params)
 
-    assert_requested :delete, 'http://localhost/test/resource'
-    # webmock doesn't seem to track query params...?
-    # assert_requested :get, 'http://localhost/test/resource', query: {'test' => '123_%CF%BF_test'}
-    assert_requested :delete, 'http://localhost/test/resource', body: ''
-    assert_not_requested :delete, 'http://localhost/test/resource', headers: {'Content-Type' => /.*\S.*/}
-    assert_requested :delete, 'http://localhost/test/resource', headers: {'x-ts-auth-method' => 'HMAC-SHA256'}
-    assert_requested :delete, 'http://localhost/test/resource', headers: {'x-ts-nonce' => /.*\S.*/}
-    assert_requested :delete, 'http://localhost/test/resource', headers: {'Date' => /.*\S.*/}
+    assert_requested :delete, 'http://localhost/test/resource?test=123_%CF%BF_test'
+    assert_requested :delete, 'http://localhost/test/resource?test=123_%CF%BF_test', body: ''
+    assert_not_requested :delete, 'http://localhost/test/resource?test=123_%CF%BF_test', headers: {'Content-Type' => /.*\S.*/}
+    assert_requested :delete, 'http://localhost/test/resource?test=123_%CF%BF_test', headers: {'x-ts-auth-method' => 'HMAC-SHA256'}
+    assert_requested :delete, 'http://localhost/test/resource?test=123_%CF%BF_test', headers: {'x-ts-nonce' => /.*\S.*/}
+    assert_requested :delete, 'http://localhost/test/resource?test=123_%CF%BF_test', headers: {'Date' => /.*\S.*/}
   end
 
   def test_phoneid


### PR DESCRIPTION
Fixes telesign/ruby_telesign_enterprise#2