### PR TITLE
Remove appverify requirement from telesign.rb

### DIFF
--- a/lib/telesign.rb
+++ b/lib/telesign.rb
@@ -1,4 +1,3 @@
-require 'telesign/appverify'
 require 'telesign/messaging'
 require 'telesign/phoneid'
 require 'telesign/rest'


### PR DESCRIPTION
Version 3.0.0 of this gem cannot boot because this appverify was removed:
https://github.com/TeleSign/ruby_telesign/commit/e675a5e34d862bbc97e4d35f2304acb71fb37e35

I'm honestly surprised that this made it pass CI...if there is one.

Can we get a new release after this lands?